### PR TITLE
[Fix] doFrontendLogout()

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -123,6 +123,7 @@ class JoomlaBrowser extends WebDriver
 		$I->amOnPage('/index.php?option=com_users&view=login');
 		$this->debug('I click Logout button');
 		$I->click(['xpath' => "//div[@class='logout']//button[contains(text(), 'Log out')]"]);
+		$I->amOnPage('/index.php?option=com_users&view=login');
 		$this->debug('I wait to see Login form');
 		$I->waitForElement(['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"], 30);
 		$I->seeElement(['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"]);


### PR DESCRIPTION
When logging out in J3.7.x it redirects to `index.php/en/` instead of the user login view causing the test to fail.

To fix this we go back to the login view after logging out, then check if the login form is shown just as before